### PR TITLE
Specify image height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
-[![laying](/resource/me.svg)](https://vladde.net/)
+<a href="https://vladde.net/">
+  <img src="/resource/me.svg" height="300px">
+</a>
 
 <samp><sub>have a good day</sub></samp>
 


### PR DESCRIPTION
Image does not jump from 0px to its default size when loading the page. Instead it is set to 300px by default.